### PR TITLE
Update 07_01_Metadata notebook with Kubeflow Metadata SDK 0.3.1 support

### DIFF
--- a/notebooks/07_Experiment_Tracking/07_01_Metadata.ipynb
+++ b/notebooks/07_Experiment_Tracking/07_01_Metadata.ipynb
@@ -45,14 +45,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
-    "# To use the latest publish `kfmd` library, you can run:\n",
-    "!pip install kfmd --user\n",
+    "# To use the latest publish `kubeflow-metadata` library, you can run:\n",
+    "!pip install kubeflow-metadata --user\n",
     "\n",
-    "# Install other packages used in the turorial:\n",
-    "!pip install pandas --user"
+    "# Install other packages:\n",
+    "!pip install pandas --user\n",
+    "# Then restart the Notebook kernel."
    ]
   },
   {
@@ -62,9 +65,19 @@
    "outputs": [],
    "source": [
     "# Verify Installation\n",
-    "from kfmd import metadata\n",
     "import pandas\n",
+    "from kubeflow.metadata import metadata\n",
     "from datetime import datetime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "METADATA_STORE_HOST = \"metadata-grpc-service.kubeflow\" # default DNS of Kubeflow Metadata gRPC serivce.\n",
+    "METADATA_STORE_PORT = 8080"
    ]
   },
   {
@@ -90,8 +103,8 @@
    "outputs": [],
    "source": [
     "test_workspace = metadata.Workspace(\n",
-    "    # Connect to metadata-service in namesapce kubeflow in k8s cluster.\n",
-    "    backend_url_prefix=\"metadata-service.kubeflow:8080\",\n",
+    "    # Connect to metadata service in namespace kubeflow in k8s cluster.\n",
+    "    store=metadata.Store(grpc_host=METADATA_STORE_HOST, grpc_port=METADATA_STORE_PORT),\n",
     "    name=\"test_workspace\",\n",
     "    description=\"a workspace for testing\",\n",
     "    labels={\"foo\": \"bar\"})"
@@ -218,8 +231,8 @@
     "            description=\"validating the MNIST model to recognize handwritten digits\",\n",
     "            owner=\"someone@kubeflow.org\",\n",
     "            uri=\"s3://my-bucket/mnist-eval.csv\",\n",
-    "            data_set_id=data_set.id,\n",
-    "            model_id=model.id,\n",
+    "            data_set_id=str(data_set.id),\n",
+    "            model_id=str(model.id),\n",
     "            metrics_type=metadata.Metrics.VALIDATION,\n",
     "            values={\"accuracy\": 0.95},\n",
     "            labels={\"mylabel\": \"l1\"}))\n",
@@ -259,16 +272,15 @@
     "print(\"model id is %s\\n\" % model.id)\n",
     "    \n",
     "# Find the execution that produces this model.\n",
-    "output_events = test_workspace.client.list_events2(model.id).events\n",
-    "assert len(output_events) == 1\n",
-    "execution_id = output_events[0].execution_id\n",
+    "output_events = test_workspace.store.get_events_by_artifact_ids([model.id])\n",
     "\n",
-    "# Find all events related to that execution.\n",
-    "all_events = test_workspace.client.list_events(execution_id).events\n",
-    "assert len(all_events) == 3\n",
+    "execution_id = set(e.execution_id for e in output_events)\n",
+    "print(\"All executions related to the model are {}\".format(execution_id))\n",
     "\n",
-    "print(\"\\nAll events related to this model:\")\n",
-    "pandas.DataFrame.from_dict([e.to_dict() for e in all_events])"
+    "trainer_events = test_workspace.store.get_events_by_execution_ids([exec.id])\n",
+    "artifact_ids = set(e.artifact_id for e in trainer_events)\n",
+    "\n",
+    "print(\"All artifacts related to the training event are {}\".format(artifact_ids))"
    ]
   },
   {
@@ -294,7 +306,7 @@
     "import argparse\n",
     "import time\n",
     "\n",
-    "from kfmd import metadata\n",
+    "from kubeflow.metadata import metadata\n",
     "\n",
     "\n",
     "# Reduce spam logs from s3 client\n",
@@ -361,7 +373,7 @@
     "  # Setting up metadata tracking\n",
     "  mnist_workspace = metadata.Workspace(\n",
     "    # Connect to metadata-service in namesapce kubeflow in k8s cluster.\n",
-    "    backend_url_prefix=\"metadata-service.kubeflow:8080\",\n",
+    "    store=metadata.Store(grpc_host=METADATA_STORE_HOST, grpc_port=METADATA_STORE_PORT),\n",
     "    name=\"mnist\",\n",
     "    description=\"Mnist image classification\",\n",
     "    labels={\"env\": \"develop\"})\n",
@@ -401,7 +413,7 @@
     "        name=\"MNIST\",\n",
     "        description=\"model to recognize handwritten digits\",\n",
     "        owner=\"someone@kubeflow.org\",\n",
-    "        uri=model_export_path,\n",
+    "        uri=str(model_export_path),\n",
     "        model_type=\"neural network\",\n",
     "        training_framework={\n",
     "            \"name\": \"tensorflow\",\n",
@@ -422,8 +434,8 @@
     "            description=\"validating the MNIST model to recognize handwritten digits\",\n",
     "            owner=\"someone@kubeflow.org\",\n",
     "            uri=\"s3://my-bucket/mnist-eval.csv\",\n",
-    "            data_set_id=dataset.id,\n",
-    "            model_id=metadata_model.id,\n",
+    "            data_set_id=str(dataset.id),\n",
+    "            model_id=str(metadata_model.id),\n",
     "            metrics_type=metadata.Metrics.VALIDATION,\n",
     "            values={\"accuracy\": 0.95},\n",
     "            labels={\"mylabel\": \"l1\"}))\n",
@@ -437,8 +449,8 @@
     "              description=\"validating the MNIST model to recognize handwritten digits\",\n",
     "              owner=\"someone@kubeflow.org\",\n",
     "              uri=\"s3://my-bucket/mnist-eval.csv\",\n",
-    "              data_set_id=dataset.id,\n",
-    "              model_id=metadata_model.id,\n",
+    "              data_set_id=str(dataset.id),\n",
+    "              model_id=str(metadata_model.id),\n",
     "              metrics_type=metadata.Metrics.VALIDATION,\n",
     "              values={\"time\": duration_in_seconds},\n",
     "              labels={\"mylabel\": \"l1\"}))"
@@ -455,9 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "You can go to central dashboard -> Artifact Store to check details.\n",
     "![artifact](./images/artifact_store.jpg)\n",
@@ -490,7 +500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/07_Experiment_Tracking/07_01_Metadata.ipynb
+++ b/notebooks/07_Experiment_Tracking/07_01_Metadata.ipynb
@@ -463,7 +463,7 @@
     "![artifact](./images/artifact_store.jpg)\n",
     "\n",
     "You can click name and check details.\n",
-    "![artifact](./images/artifact_mnist.jpg)"
+    "![artifact](./images/artifacts_mnist.jpg)"
    ]
   },
   {


### PR DESCRIPTION
*Issue #28 , if available:*
* Since Kubeflow Metadata has released SDK 0.3.1 and a newer version of [example](https://github.com/kubeflow/metadata/blob/master/sdk/python/sample/demo.ipynb), I also update our corresponding Metadata notebook.

* A small issue is in the [07_01_Metadata](https://github.com/aws-samples/eks-kubeflow-workshop/blob/master/notebooks/07_Experiment_Tracking/07_01_Metadata.ipynb) notebook, at the bottom of the notebook, the image is not represented well.

*Description of changes:*
* Add support for Kubeflow Metadata SDK 0.3.1.

* The reason for the issue is the image name mismatched, simply modify the image name fix the problem. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
