### PR TITLE
Fix AmazonS3FullAccess Missing IAM Policy issue

### DIFF
--- a/notebooks/02_Fairing/README.md
+++ b/notebooks/02_Fairing/README.md
@@ -7,7 +7,7 @@ I build a container image with awscli and docker support, Please use `seedjeffwa
 
 ### ECR permission
 
-Since fairing library will create ECR repository and upload repository to ECR. Grant `AmazonEC2ContainerRegistryFullAccess` to your node group role.  (We will use simplest policies instead later)
+Since fairing library will create ECR repository, upload repository to ECR, and put objects in S3 bucket. Grant `AmazonEC2ContainerRegistryFullAccess` and `AmazonS3FullAccess` to your node group role.  (We will use simplest policies instead later)
 
 ### Disable istio inject for your namespace(Optional)
 In order to succesfully run fairing, you need to label your namespace. `anonymous` is the namespace we want to use, change to your namespace if you use a different one

--- a/notebooks/05_Kubeflow_Pipeline/05_04_Pipeline_SageMaker.ipynb
+++ b/notebooks/05_Kubeflow_Pipeline/05_04_Pipeline_SageMaker.ipynb
@@ -84,11 +84,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Typically in a production environment, you would assign fine-grained permissions depending on the nature of actions you take and leverage tools like [IAM Role for Service Account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for securing access to AWS resources but for simplicity we will assign AmazonSageMakerFullAccess IAM policy.  You can read more about granular policies [here](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html) \n",
+    "> Typically in a production environment, you would assign fine-grained permissions depending on the nature of actions you take and leverage tools like [IAM Role for Service Account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for securing access to AWS resources but for simplicity we will assign AmazonSageMakerFullAccess and AmazonS3FullAccess IAM policy.  You can read more about granular policies [here](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html) \n",
     "\n",
     "> In order to run this pipeline, we need two levels of IAM permissions\n",
     "\n",
-    "> a) create Kubernetes secrets **aws-secret** with Sagemaker policies. Please make sure to create `aws-secret` in kubeflow namespace.\n",
+    "> a) create Kubernetes secrets **aws-secret** with Sagemaker and S3 policies. Please make sure to create `aws-secret` in kubeflow namespace.\n",
     "\n",
     "```yaml\n",
     "apiVersion: v1\n",
@@ -103,7 +103,7 @@
     "```\n",
     "> Note: To get base64 string, try `echo -n $AWS_ACCESS_KEY_ID | base64`\n",
     "\n",
-    "> b) create an IAM execution role for Sagemaker so that the job can assume this role in order to perform Sagemaker actions. Make a note of this role as you will need it during pipeline creation step\n"
+    "> b) create an IAM execution role for Sagemaker and S3 so that the job can assume this role in order to perform Sagemaker and S3 actions. Make a note of this role as you will need it during pipeline creation step\n"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
If we don't attach S3FullAccess IAM Policy, we'll encountered the issue below:

For `02_02_fairing_job_backend.ipynb` notebook:
![image](https://user-images.githubusercontent.com/23116624/77353106-9c1ea080-6cfd-11ea-8635-c2b525dcb8b3.png)

For `05_04_Pipeline_SageMaker.ipynb` notebook:
![image](https://user-images.githubusercontent.com/23116624/77353152-b193ca80-6cfd-11ea-8e3f-d87daed13c93.png)

*Description of changes:*
Mention in the description that we need to attach `AmazonS3FullAccess` policy. I tested locally and it works after I attached `AmazonS3FullAccess` policy.

Overall, it's found when I tested `eks-kubeflow-workshop` with `kubeflow 1.0.1`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
