### PR TITLE
Fix Clusterrole issue

### DIFF
--- a/notebooks/03_Distributed_Training/03_02_Distributed_Training_MPI_Horovod.ipynb
+++ b/notebooks/03_Distributed_Training/03_02_Distributed_Training_MPI_Horovod.ipynb
@@ -91,6 +91,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "### Prerequiste: \n",
+    "1. Update default-editor roles\n",
+    "\n",
+    "    There's an upstream isuse that default-editor doesn't have permission to create mpijobs.\n",
+    "\n",
+    "    Adding this on Clusterrole to skip error: User \"system:serviceaccount:kubeflow:default-editor\" cannot create resource \"mpijobs\" in API group \"kubeflow.org\" in the namespace \"kubeflow\"\n",
+    "\n",
+    "    ```shell\n",
+    "    kubectl edit clusterrole kubeflow-edit -n kubeflow\n",
+    "    ```\n",
+    "\n",
+    "    Add following policies to cluster role lists.\n",
+    "    ```yaml\n",
+    "    - apiGroups:\n",
+    "      - kubeflow.org\n",
+    "      resources:\n",
+    "      - '*'\n",
+    "      verbs:\n",
+    "      - '*'\n",
+    "    ```"
+   ],
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -175,13 +201,6 @@
     "\n",
     "GPU instance are every expensive, remember to scale down the nodes when you finish the job"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
*Issue #, if available:*
The issue is when we execute `03_02_Distributed_Training_MPI_Horovod` notebook, the `!kubectl apply -f distributed-training-jobs/distributed-mpi-job.yaml` returns error: 

```
User "system:serviceaccount:kubeflow:default-editor" cannot create resource "mpijobs" in the API group "kubeflow.org" in the namespace "kubeflow"
```

*Description of changes:*

Edit sa `default-editor` to have the privilege to create resource in "kubeflow.org"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
