### PR TITLE
Fix 09_01_Iris_Pipeline_Monitoring component wrong settings and SSL verification issue

### DIFF
--- a/notebooks/09_Monitoring/src/09_01_Iris_Pipeline_Monitoring/component.yaml
+++ b/notebooks/09_Monitoring/src/09_01_Iris_Pipeline_Monitoring/component.yaml
@@ -9,7 +9,7 @@ inputs:
     description: 'The S3 bucket name'
     default: ''
 outputs:
-  - {name: model_artifact_url, description: 'Model ARTIFACT URL'}
+  - {name: mlpipeline-ui-metadata, description: 'Pipeline ARTIFACT URL'}
 implementation:
   container: 
     image: chuckshow/iris-pipeline:latest

--- a/notebooks/09_Monitoring/src/09_01_Iris_Pipeline_Monitoring/model.py
+++ b/notebooks/09_Monitoring/src/09_01_Iris_Pipeline_Monitoring/model.py
@@ -7,6 +7,7 @@ import boto3
 import tensorflow as tf
 import datetime
 import argparse
+import ssl
 
 from sklearn import model_selection
 from sklearn.metrics import confusion_matrix, roc_curve
@@ -209,6 +210,9 @@ def main(argv=None):
     args = parser.parse_args()
 
     logging.getLogger().setLevel(logging.INFO)
+    
+    # Bypass ssl verification
+    ssl._create_default_https_context = ssl._create_unverified_context    
 
     # Preprocess
     X_train, X_test, y_train, y_test = preprocess(args)


### PR DESCRIPTION
*Issue #, if available:*
In `component.yaml` file, the `output` mismatched with `fileOutputs`

After Python3.6, it doesn't pre-install `certifact`, thus, when reading from `https` URL, it will result in the SSL verification issue.

*Description of changes:*
Modified `output.name` for correct settings.

To bypass the SSL verification issue, I avoid verifying SSL cert.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
