### PR TITLE
Update Fairing Instructions with kfctl 1.0 compatibility

### DIFF
--- a/notebooks/02_Fairing/02_03_fairing_distributed_training.ipynb
+++ b/notebooks/02_Fairing/02_03_fairing_distributed_training.ipynb
@@ -131,6 +131,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To avoid a [recently introduced issue](https://github.com/kubernetes-client/python/issues/1112), run below commands to install Kubernetes Client version 10.0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install kubernetes==10.0.1 --user"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/notebooks/02_Fairing/02_06_fairing_e2e.ipynb
+++ b/notebooks/02_Fairing/02_06_fairing_e2e.ipynb
@@ -355,8 +355,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Clean up S3 bucket\n",
-    "Delete S3 bucket that was created for this exercise"
+    "### Clean up S3 bucket and ECR Repository\n",
+    "Delete S3 bucket and ECR Repository that was created for this exercise"
    ]
   },
   {
@@ -365,7 +365,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!aws s3 rb s3://$S3_BUCKET --force"
+    "!aws s3 rb s3://$S3_BUCKET --force\n",
+    "!aws ecr delete-repository --repository-name fairing-job --region $AWS_REGION --force"
    ]
   }
  ],

--- a/notebooks/02_Fairing/README.md
+++ b/notebooks/02_Fairing/README.md
@@ -12,18 +12,25 @@ I build a container image with awscli and docker support, Please use `seedjeffwa
 
 Since fairing library will create ECR repository, upload repository to ECR, and put objects in S3 bucket. Grant `AmazonEC2ContainerRegistryFullAccess` and `AmazonS3FullAccess` to your node group role.  (We will use simplest policies instead later)
 
-### Disable istio inject for your namespace(Optional)
-In order to succesfully run fairing, you need to label your namespace. `anonymous` is the namespace we want to use, change to your namespace if you use a different one
+We also provide an option to enable IAM Roles for Service Account. If you configure kubeflow from [option 1](https://www.kubeflow.org/docs/aws/deploy/install-kubeflow/#option-1-use-iam-for-service-account), then you can attach IAM Role `kf-user-${cluster_name}` with below policies which enables ECR and S3 operation.
 
 ```
- kubectl edit ns anonymous
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:*",
+                "cloudtrail:LookupEvents"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": "*"
+        }
+    ]
+}
 ```
-
-Be default, istio inject is enabled at the namespace level. Add `istio-injection: disabled` to avoid istio inject sidecar pods.
-
-```
-  labels:
-    istio-injection: disabled
-```
-
-Check [Disable istio-injection in namespace profile controller creates?](https://github.com/kubeflow/kubeflow/issues/3935) for details


### PR DESCRIPTION
*Issue #35 , if available:*
We have issues in kfctl 0.7, after 1.0 release, some of the issues are addressed.

*Description of changes:*
I tested Fairing notebook with kfctl 1.0, removed redundant instructions, and add instructions for enabling IAM Role for Service Account. Also proposed workaround for fixing newly introduced issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
