### PR TITLE
fix function parameters call from `str` to `int`

### DIFF
--- a/notebooks/05_Kubeflow_Pipeline/05_02_Pipeline_lightweight.ipynb
+++ b/notebooks/05_Kubeflow_Pipeline/05_02_Pipeline_lightweight.ipynb
@@ -99,7 +99,7 @@
     "   description='A toy pipeline that performs arithmetic calculations.'\n",
     ")\n",
     "def calculate_sum_lightweight(\n",
-    "   a='a',\n",
+    "   a='2',\n",
     "   b='7',\n",
     "   c='17',\n",
     "   d='4'\n",


### PR DESCRIPTION
*Issue #, if available:*
The function expect 2 int, or the first parameter is a `str`, which makes the pipeline to break

*Description of changes:*
updated the first parameter from str to an int

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
