### PR TITLE
Fix Minor issues for Kubeflow v1.0.2 compatibility test

### DIFF
--- a/notebooks/03_Distributed_Training/03_01_Distributed_Training_ParameterServer.ipynb
+++ b/notebooks/03_Distributed_Training/03_01_Distributed_Training_ParameterServer.ipynb
@@ -48,11 +48,6 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Examples\n",
     "\n",

--- a/notebooks/05_Kubeflow_Pipeline/05_02_Pipeline_lightweight.ipynb
+++ b/notebooks/05_Kubeflow_Pipeline/05_02_Pipeline_lightweight.ipynb
@@ -147,13 +147,6 @@
     "\n",
     "Please follow [instructions](https://www.kubeflow.org/docs/gke/pipelines-tutorial/#run-the-pipeline) to run your pipeline "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/05_Kubeflow_Pipeline/05_03_Pipeline_mnist.ipynb
+++ b/notebooks/05_Kubeflow_Pipeline/05_03_Pipeline_mnist.ipynb
@@ -29,38 +29,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Prerequiste: \n",
-    "1. Update pipeline-runner roles"
+    "### Prerequiste: \n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There's an upstream isuse that pipeline-runner doesn't have permission to create istio virtual service\n",
-    "\n",
-    "Adding this on Clusterrole to skip error: User \"system:serviceaccount:kubeflow:pipeline-runner\" cannot create resource \"virtualservices\" in API group \"networking.istio.io\" in the namespace \"kubeflow\"\n",
-    "\n",
-    "```shell\n",
-    "kubectl edit clusterrole pipeline-runner -n kubeflow\n",
-    "```\n",
-    "\n",
-    "Add following policies to cluster role lists.\n",
-    "```yaml\n",
-    "- apiGroups:\n",
-    "  - networking.istio.io\n",
-    "  resources:\n",
-    "  - '*'\n",
-    "  verbs:\n",
-    "  - '*'\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "2. Create a aws-secret with `AmazonS3FullAccess` policy in `kubeflow` namespace.\n",
+    "1. Create a aws-secret with `AmazonS3FullAccess` policy in `kubeflow` namespace.\n",
     "\n",
     "```yaml\n",
     "kind: Secret\n",
@@ -91,6 +67,22 @@
    "source": [
     "mnist_bucket= \"e2e-mnist-example\"\n",
     "s3_bucket_path = 's3://{}'.format(mnist_bucket)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Replace aws_region with your region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aws_region = \"us-west-2\""
    ]
   },
   {
@@ -157,7 +149,8 @@
     "    \n",
     "    chief, worker = tfjoblaunch_args_provider.tfjoblauncher_args(step=step, \n",
     "                                                                 s3bucketexportpath=s3bucketexportpath, \n",
-    "                                                                 args=op2.output)\n",
+    "                                                                 args=op2.output, \n",
+    "                                                                 aws_region=aws_region)\n",
     "    \n",
     "    train = tfjob_launcher_op(\n",
     "        name=name,\n",
@@ -166,7 +159,7 @@
     "        worker_spec=worker,\n",
     "        chief_spec=chief,\n",
     "        tfjob_timeout_minutes=tfjobTimeoutMinutes,\n",
-    "        delete_finished_tfjob=deleteAfterDone,\n", 
+    "        delete_finished_tfjob=deleteAfterDone,\n",
     "    )\n",
     "    \n",
     "    # step 3: model inferencese by Tensorflow Serving    \n",
@@ -175,7 +168,8 @@
     "    \n",
     "    deploy = resource_provider.tfservingdeploy_resource(namespace=namespace,\n",
     "                                                       s3bucketexportpath=s3bucketexportpath,\n",
-    "                                                       servingdeploy_name=servingdeploy_name)\n",
+    "                                                       servingdeploy_name=servingdeploy_name,\n",
+    "                                                       aws_region=aws_region) \n",
     "    \n",
     "    deployment = dsl.ResourceOp(\n",
     "        name=\"deploy\",\n",
@@ -330,10 +324,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/notebooks/05_Kubeflow_Pipeline/05_04_Pipeline_SageMaker.ipynb
+++ b/notebooks/05_Kubeflow_Pipeline/05_04_Pipeline_SageMaker.ipynb
@@ -43,8 +43,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install sagemaker https://storage.googleapis.com/ml-pipeline/release/0.1.29/kfp.tar.gz --upgrade\n",
-        "!pip install boto3 --user\n",
+        "!pip install sagemaker kfp boto3 --upgrade --user\n",
         "!pip show kfp"
       ],
       "outputs": [],

--- a/notebooks/05_Kubeflow_Pipeline/src/mnist/src/resource_provider.py
+++ b/notebooks/05_Kubeflow_Pipeline/src/mnist/src/resource_provider.py
@@ -192,7 +192,7 @@ def tfservingsvc_resource(namespace, servingdeploy_name, servingsvc_name):
     return serviceresource
     
 
-def tfservingdeploy_resource(namespace, s3bucketexportpath, servingdeploy_name):
+def tfservingdeploy_resource(namespace, s3bucketexportpath, servingdeploy_name, aws_region="us-west-2"):
     deployjson_template = Template("""
     {
       "apiVersion": "apps/v1",
@@ -236,7 +236,7 @@ def tfservingdeploy_resource(namespace, s3bucketexportpath, servingdeploy_name):
                 "env": [
                   {
                     "name": "AWS_REGION",
-                    "value": "us-west-2"
+                    "value": "$aws_region"
                   },
                   {
                     "name": "AWS_ACCESS_KEY_ID",
@@ -297,6 +297,7 @@ def tfservingdeploy_resource(namespace, s3bucketexportpath, servingdeploy_name):
             {'namespace': namespace,
              's3bucketexportpath': s3bucketexportpath,
              'servingdeploy': servingdeploy_name,
+             'aws_region': aws_region
             })
     
     deploy = json.loads(deployjson)

--- a/notebooks/05_Kubeflow_Pipeline/src/mnist/src/tfjoblaunch_args_provider.py
+++ b/notebooks/05_Kubeflow_Pipeline/src/mnist/src/tfjoblaunch_args_provider.py
@@ -1,4 +1,4 @@
-def tfjoblauncher_args(step, s3bucketexportpath, args):
+def tfjoblauncher_args(step, s3bucketexportpath, args, aws_region="us-west-2"):
     chief = {
         "replicas": 1,
         "restartPolicy": "OnFailure",
@@ -23,7 +23,7 @@ def tfjoblauncher_args(step, s3bucketexportpath, args):
                         "env": [
                             {
                                 "name": "AWS_REGION",
-                                "value": "us-west-2"
+                                "value": aws_region
                             },
                             {
                                 "name": "AWS_ACCESS_KEY_ID",
@@ -74,7 +74,7 @@ def tfjoblauncher_args(step, s3bucketexportpath, args):
                         "env": [
                             {
                                 "name": "AWS_REGION",
-                                "value": "us-west-2"
+                                "value": aws_region
                             },
                             {
                                 "name": "AWS_ACCESS_KEY_ID",
@@ -102,5 +102,3 @@ def tfjoblauncher_args(step, s3bucketexportpath, args):
     }
 
     return chief, worker
-
-

--- a/notebooks/07_Experiment_Tracking/07_01_Metadata.ipynb
+++ b/notebooks/07_Experiment_Tracking/07_01_Metadata.ipynb
@@ -475,13 +475,6 @@
     "You can click name and check details.\n",
     "![artifact](./images/artifacts_mnist.jpg)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/08_Hyperparameter_Tuning/08_01_Hyper_Parameter_Tuning.ipynb
+++ b/notebooks/08_Hyperparameter_Tuning/08_01_Hyper_Parameter_Tuning.ipynb
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kubectl describe experiment random-search-example"
+    "!kubectl describe experiment random-example"
    ]
   },
   {


### PR DESCRIPTION
*Issue #53  #44 , if available:*
Since Kubeflow v1.0.2 released, I tested eks-kubeflow-workshop and fix some minor issues.

AWS_REGION was fixed as `us-west-2`.

*Description of changes:*
The main change is removing `kubectl edit clusterrole pipeline-runner -n kubeflow`, which saves manually manipulating.

Expose AWS Region to users for customization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
