### PR TITLE
Create 1.17 EKS cluster instead

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -18,7 +18,7 @@ kind: ClusterConfig
 metadata:
   name: kfworkshop
   region: us-west-2
-  version: '1.13'
+  version: '1.17'
 # If your region has multiple availability zones, you can specify 3 of them.
 availabilityZones: ["us-west-2b", "us-west-2c", "us-west-2d"]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
EKS Cluster Version `1.13` has been deprecated for a while, use `1.17` instead

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
